### PR TITLE
Changed 'create_if_not_exists' to 'create' in pdf_metadata.py

### DIFF
--- a/src/media_types/metadata/pdf_metadata.py
+++ b/src/media_types/metadata/pdf_metadata.py
@@ -70,7 +70,7 @@ class PDFMetadata(GenericMetadata):
                         "thumbnail_path" in archive_dict
                         and len(archive_dict["thumbnail_path"]) > 0
                     ):
-                        self.create_if_not_exists(
+                        self.create(
                             self.env["archive_table"], archive_dict, "Archive", idx
                         )
                     else:


### PR DESCRIPTION
**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
-This pull request changes 'create_if_not_exists' function to 'create' in pdf_metadata.py. While refactoring changes for bulk metadata updates in metadata.py, the function 'create_if_not_exists' was renamed as 'create'. But this change was not reflected in pdf_metadata.py. This creates an error while trying to update pdf metadata. This pull request addresses this error.

# What's the changes? (:star:)
Only one change: renaming 'create_if_not_exists' to 'create' in pdf_metadata.py


# How should this be tested?

A description of what steps someone could take to:
* Outline the steps to test or reproduce the PR here.
* Please be as detailed as possible.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* What branch to be used for testing this PR?
* Does this change require documentation to be updated?
* Does this change add any new dependencies?
* Does this change require any other modifications to be made to the repository?
* Could this change impact execution of existing code?

# Interested parties
Tag (@ mention) interested parties
@whunter 
@goynejennifer

(:star:) Required fields